### PR TITLE
Introduce Battery Watch Functionality

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,38 +3,58 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
+	"time"
 
 	"github.com/rsjethani/sysinfo"
 )
 
-var threshold uint
-var notif bool
+var argWatch bool
+var argThreshold uint
+var argLowInterval time.Duration
+var argNormalInterval time.Duration
+
+func init() {
+	flag.BoolVar(&argWatch, "w", false, "continously watch battery status")
+	flag.DurationVar(&argLowInterval, "l", time.Minute*2, "battery check interval during low battery")
+	flag.DurationVar(&argNormalInterval, "n", time.Minute*10, "battery check interval during good battery")
+	flag.UintVar(&argThreshold, "t", 20, "threshold below which battery capacty would be considered critical")
+}
 
 func main() {
-	flag.UintVar(&threshold, "t", 20, "threshold of critical situation")
-	flag.BoolVar(&notif, "n", false, "enable send notification")
 	flag.Parse()
 
-	info, err := sysinfo.GetInfo("hardware", "battery")
+	for {
 
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+		info, err := sysinfo.GetInfo("hardware", "battery")
 
-	c, _ := info.Attribute(0, "CAPACITY")
-	capacity, _ := c.(uint)
-	s, _ := info.Attribute(0, "STATUS")
-	state, _ := s.(string)
-
-	fmt.Println(capacity, state)
-
-	if notif {
-		err = sendNotification(capacity, state)
 		if err != nil {
-			fmt.Println("an error on displaying notification occured: %s", err)
-			os.Exit(2)
+			fmt.Println(err)
+			os.Exit(1)
 		}
+
+		c, _ := info.Attribute(0, "CAPACITY")
+		capacity, _ := c.(uint)
+		s, _ := info.Attribute(0, "STATUS")
+		state, _ := s.(string)
+
+		log.Println(capacity, state)
+
+		if argWatch {
+			sleepInterval := argNormalInterval
+			if capacity < argThreshold {
+				sleepInterval = argLowInterval
+				err = sendNotification(capacity, state)
+				if err != nil {
+					fmt.Println("an error on displaying notification occured: %s", err)
+					os.Exit(2)
+				}
+			}
+			time.Sleep(sleepInterval)
+			continue
+		}
+
+		break
 	}
 }

--- a/notification.go
+++ b/notification.go
@@ -14,13 +14,13 @@ func sendNotification(percentage uint, chargingState string) error {
 	}
 
 	urgency := 1 // normal
-	if percentage < threshold {
+	if percentage < 5 {
 		urgency = 2 //critical
 	}
 
 	n := notify.Notification{
 		AppName:       "Battery Notifier",
-		ReplacesID:    uint32(0),
+		ReplacesID:    0,
 		AppIcon:       notificationIcon(percentage, chargingState),
 		Body:          notificationSummary(percentage),
 		Summary:       notificationTitle(percentage),
@@ -38,7 +38,7 @@ func notificationTitle(percentage uint) string {
 
 func batteryAdjective(percentage uint) string {
 	switch {
-	case percentage <= threshold:
+	case percentage <= argThreshold:
 		return "LOW"
 	case percentage <= 50:
 		return "is OK"
@@ -51,7 +51,7 @@ func batteryAdjective(percentage uint) string {
 
 func notificationSummary(percentage uint) string {
 	switch {
-	case percentage <= threshold:
+	case percentage <= argThreshold:
 		return "Please Connect Charger to Device"
 	default:
 		return ""
@@ -73,7 +73,7 @@ func chargingIcon(percentage uint) string {
 	switch {
 	case percentage <= 1:
 		return "battery-empty"
-	case percentage <= threshold:
+	case percentage <= argThreshold:
 		return "battery-low-charging"
 	case percentage == 100:
 		return "battery-full-charged"
@@ -86,7 +86,7 @@ func nonChargingIcon(percentage uint) string {
 	switch {
 	case percentage <= 1:
 		return "battery-empty"
-	case percentage <= threshold:
+	case percentage <= argThreshold:
 		return "battery-low"
 	case percentage == 100:
 		return "battery-full"


### PR DESCRIPTION
If `argWatch` (-w option) is given then:

* Check battery after every `argLowInternval` minutes (-l option) if battery is
  below threshold.
* Check battery after every `argNormalInternval` minutes (-n option) if battery is
  above threshold.
* Print current battery capacity and state and send a desktop notification.

Else:
 Just print current battery capacity and state and exit.